### PR TITLE
Fix cookie param handling tests

### DIFF
--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/CookieParamTest.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/CookieParamTest.java
@@ -86,7 +86,7 @@ public class CookieParamTest extends ParamTest {
         Response.ResponseBuilder respb = Response.status(200);
 
         if (todo == null) {
-            sb.append("todo=null");
+            sb.append("other stuff");
         } else if (todo.equalsIgnoreCase("setCookie")) {
             String cookie_name = "name1";
             String cookie_value = "value1";


### PR DESCRIPTION
Fix cookie param tests, that break because of the change of how empty query parameters are handled by resteasy -> https://github.com/quarkusio/quarkus/pull/42468