### PR TITLE
Fix handling of empty todo query parameter

### DIFF
--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/CookieParamTest.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/CookieParamTest.java
@@ -86,7 +86,15 @@ public class CookieParamTest extends ParamTest {
         Response.ResponseBuilder respb = Response.status(200);
 
         if (todo == null) {
-            sb.append("other stuff");
+            setReturnValues(paramEntityWithConstructor, paramEntityWithFromString,
+                    paramEntityWithValueOf, setParamEntityWithFromString,
+                    sortedSetParamEntityWithFromString, listParamEntityWithFromString,
+                    "");
+            setReturnValues(fieldParamEntityWithConstructor,
+                    fieldParamEntityWithFromString, fieldParamEntityWithValueOf,
+                    fieldSetParamEntityWithFromString,
+                    fieldSortedSetParamEntityWithFromString,
+                    fieldListParamEntityWithFromString, FIELD);
         } else if (todo.equalsIgnoreCase("setCookie")) {
             String cookie_name = "name1";
             String cookie_value = "value1";
@@ -98,6 +106,7 @@ public class CookieParamTest extends ParamTest {
             sb.append("name1" + "=" + value);
             sb.append("verifyCookie=done");
         } else if (todo.equals("")) {
+            // TODO this block can be removed after https://github.com/quarkusio/quarkus/pull/42468 is merged, kept only for backwards compat
             setReturnValues(paramEntityWithConstructor, paramEntityWithFromString,
                     paramEntityWithValueOf, setParamEntityWithFromString,
                     sortedSetParamEntityWithFromString, listParamEntityWithFromString,


### PR DESCRIPTION
Same goal as https://github.com/quarkusio/resteasy-reactive-testsuite/pull/8, to adapt the tests to new empty parameter behavior introduced by https://github.com/quarkusio/quarkus/pull/42468, except this actually fixes the tests.