### PR TITLE
Use quarkus.rest.fail-on-duplicate instead of the now removed resteasy-reactive counterpart

### DIFF
--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/resource/java2entity/JAXRSClient0154.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/resource/java2entity/JAXRSClient0154.java
@@ -40,7 +40,7 @@ public class JAXRSClient0154 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_resource_java2entity_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/resource/webappexception/mapper/JAXRSClient0152.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/resource/webappexception/mapper/JAXRSClient0152.java
@@ -40,7 +40,7 @@ public class JAXRSClient0152 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_resource_webappexception_mapper_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/resource/webappexception/nomapper/JAXRSClient0153.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/resource/webappexception/nomapper/JAXRSClient0153.java
@@ -40,7 +40,7 @@ public class JAXRSClient0153 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_resource_webappexception_nomapper_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/cookie/plain/JAXRSClient0114.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/cookie/plain/JAXRSClient0114.java
@@ -41,7 +41,7 @@ public class JAXRSClient0114 extends BeanParamCommonClient0117 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_beanparam_cookie_plain_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/form/plain/JAXRSClient0113.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/form/plain/JAXRSClient0113.java
@@ -42,7 +42,7 @@ public class JAXRSClient0113 extends BeanParamCommonClient0117 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_beanparam_form_plain_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/header/plain/JAXRSClient0110.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/header/plain/JAXRSClient0110.java
@@ -42,7 +42,7 @@ public class JAXRSClient0110 extends BeanParamCommonClient0117 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_beanparam_header_plain_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/matrix/plain/JAXRSClient0112.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/matrix/plain/JAXRSClient0112.java
@@ -42,7 +42,7 @@ public class JAXRSClient0112 extends BeanParamCommonClient0117 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_beanparam_matrix_plain_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/path/plain/JAXRSClient0115.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/path/plain/JAXRSClient0115.java
@@ -41,7 +41,7 @@ public class JAXRSClient0115 extends BeanParamCommonClient0117 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_beanparam_path_plain_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/plain/JAXRSClient0116.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/plain/JAXRSClient0116.java
@@ -45,7 +45,7 @@ public class JAXRSClient0116 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_beanparam_plain_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/query/plain/JAXRSClient0111.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/beanparam/query/plain/JAXRSClient0111.java
@@ -42,7 +42,7 @@ public class JAXRSClient0111 extends BeanParamCommonClient0117 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_beanparam_query_plain_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/asyncinvoker/JAXRSClient0118.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/asyncinvoker/JAXRSClient0118.java
@@ -54,7 +54,7 @@ public class JAXRSClient0118 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_client_asyncinvoker_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/clientrequestcontext/JAXRSClient0121.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/clientrequestcontext/JAXRSClient0121.java
@@ -49,7 +49,7 @@ public class JAXRSClient0121 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_client_clientrequestcontext_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/invocationbuilder/JAXRSClient0119.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/invocationbuilder/JAXRSClient0119.java
@@ -52,7 +52,7 @@ public class JAXRSClient0119 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_client_invocationbuilder_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/syncinvoker/JAXRSClient0120.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/syncinvoker/JAXRSClient0120.java
@@ -52,7 +52,7 @@ public class JAXRSClient0120 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_client_syncinvoker_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/constrainedto/JAXRSClient0140.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/constrainedto/JAXRSClient0140.java
@@ -54,7 +54,7 @@ public class JAXRSClient0140 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_constrainedto_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/JAXRSClient0138.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/JAXRSClient0138.java
@@ -47,7 +47,7 @@ public class JAXRSClient0138 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_container_requestcontext_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/illegalstate/JAXRSClient0137.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/illegalstate/JAXRSClient0137.java
@@ -38,7 +38,7 @@ public class JAXRSClient0137 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_container_requestcontext_illegalstate_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/security/JAXRSClient0136.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/security/JAXRSClient0136.java
@@ -46,7 +46,7 @@ public class JAXRSClient0136 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_container_requestcontext_security_web")
             .overrideConfigKey("quarkus.http.auth.basic", "true")

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/resourceinfo/JAXRSClient0135.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/resourceinfo/JAXRSClient0135.java
@@ -39,7 +39,7 @@ public class JAXRSClient0135 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_container_resourceinfo_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/responsecontext/JAXRSClient0139.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/container/responsecontext/JAXRSClient0139.java
@@ -49,7 +49,7 @@ public class JAXRSClient0139 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_container_responsecontext_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/JAXRSClient0143.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/JAXRSClient0143.java
@@ -44,7 +44,7 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/locator/JAXRSLocatorClient0142.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/locator/JAXRSLocatorClient0142.java
@@ -37,7 +37,7 @@ public class JAXRSLocatorClient0142
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_locator_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/sub/JAXRSSubClient0141.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/sub/JAXRSSubClient0141.java
@@ -37,7 +37,7 @@ public class JAXRSSubClient0141
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_sub_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/application/JAXRSClient0128.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/application/JAXRSClient0128.java
@@ -45,7 +45,7 @@ public class JAXRSClient0128 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_application_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/configurable/JAXRSClient0133.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/configurable/JAXRSClient0133.java
@@ -59,7 +59,7 @@ public class JAXRSClient0133 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_configurable_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/configuration/JAXRSClient0125.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/configuration/JAXRSClient0125.java
@@ -66,7 +66,7 @@ public class JAXRSClient0125 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_configuration_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/headers/JAXRSClient0132.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/headers/JAXRSClient0132.java
@@ -49,7 +49,7 @@ public class JAXRSClient0132 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_headers_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/request/JAXRSClient0129.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/request/JAXRSClient0129.java
@@ -37,7 +37,7 @@ public class JAXRSClient0129 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_request_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/response/JAXRSClient0131.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/response/JAXRSClient0131.java
@@ -72,7 +72,7 @@ public class JAXRSClient0131 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_response_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/responsebuilder/JAXRSClient0130.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/responsebuilder/JAXRSClient0130.java
@@ -47,7 +47,7 @@ public class JAXRSClient0130 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_responsebuilder_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient0134.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient0134.java
@@ -40,7 +40,7 @@ public class JAXRSClient0134 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_uriinfo_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/delete/JAXRSClient0148.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/delete/JAXRSClient0148.java
@@ -38,7 +38,7 @@ public class JAXRSClient0148 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_delete_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/clientwriter/interceptorcontext/JAXRSClient0092.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/clientwriter/interceptorcontext/JAXRSClient0092.java
@@ -57,7 +57,7 @@ public class JAXRSClient0092 extends WriterClient0094<ContextOperation> {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_ext_interceptor_clientwriter_interceptorcontext_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/clientwriter/writerinterceptorcontext/JAXRSClient0093.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/clientwriter/writerinterceptorcontext/JAXRSClient0093.java
@@ -51,7 +51,7 @@ public class JAXRSClient0093 extends WriterClient0094<ContextOperation> {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path",
                     "/jaxrs_ee_rs_ext_interceptor_clientwriter_writerinterceptorcontext_web")

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerreader/interceptorcontext/JAXRSClient0089.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerreader/interceptorcontext/JAXRSClient0089.java
@@ -54,7 +54,7 @@ public class JAXRSClient0089 extends ReaderClient0091<ContextOperation> {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_ext_interceptor_containerreader_interceptorcontext_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerreader/readerinterceptorcontext/JAXRSClient0090.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerreader/readerinterceptorcontext/JAXRSClient0090.java
@@ -41,7 +41,7 @@ public class JAXRSClient0090 extends ReaderClient0091<ContextOperation> {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path",
                     "/jaxrs_ee_rs_ext_interceptor_containerreader_readerinterceptorcontext_web")

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerwriter/interceptorcontext/JAXRSClient0095.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerwriter/interceptorcontext/JAXRSClient0095.java
@@ -47,7 +47,7 @@ public class JAXRSClient0095 extends WriterClient0097<ContextOperation> {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_ext_interceptor_containerwriter_interceptorcontext_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerwriter/writerinterceptorcontext/JAXRSClient0096.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerwriter/writerinterceptorcontext/JAXRSClient0096.java
@@ -40,7 +40,7 @@ public class JAXRSClient0096 extends WriterClient0097<ContextOperation> {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path",
                     "/jaxrs_ee_rs_ext_interceptor_containerwriter_writerinterceptorcontext_web")

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/paramconverter/JAXRSClient0099.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/paramconverter/JAXRSClient0099.java
@@ -43,7 +43,7 @@ public class JAXRSClient0099 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_ext_paramconverter_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/providers/JAXRSProvidersClient0098.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/providers/JAXRSProvidersClient0098.java
@@ -43,7 +43,7 @@ public class JAXRSProvidersClient0098
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_ext_providers_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/JAXRSClient0146.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/JAXRSClient0146.java
@@ -41,7 +41,7 @@ public class JAXRSClient0146 extends JaxrsParamClient0151 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/locator/JAXRSLocatorClient0145.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/locator/JAXRSLocatorClient0145.java
@@ -40,7 +40,7 @@ public class JAXRSLocatorClient0145 extends JAXRSClient0146 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_locator_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/sub/JAXRSSubClient0144.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/sub/JAXRSSubClient0144.java
@@ -40,7 +40,7 @@ public class JAXRSSubClient0144 extends JAXRSClient0146 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_sub_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/get/JAXRSClient0147.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/get/JAXRSClient0147.java
@@ -40,7 +40,7 @@ public class JAXRSClient0147 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_get_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/head/JAXRSClient0104.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/head/JAXRSClient0104.java
@@ -40,7 +40,7 @@ public class JAXRSClient0104 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_head_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/JAXRSClient0108.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/JAXRSClient0108.java
@@ -43,7 +43,7 @@ public class JAXRSClient0108 extends JaxrsParamClient0151 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/locator/JAXRSLocatorClient0107.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/locator/JAXRSLocatorClient0107.java
@@ -37,7 +37,7 @@ public class JAXRSLocatorClient0107
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_locator_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/sub/JAXRSSubClient0106.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/sub/JAXRSSubClient0106.java
@@ -40,7 +40,7 @@ public class JAXRSSubClient0106
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_sub_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/JAXRSClient0102.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/JAXRSClient0102.java
@@ -43,7 +43,7 @@ public class JAXRSClient0102 extends JaxrsParamClient0151 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/locator/JAXRSLocatorClient0101.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/locator/JAXRSLocatorClient0101.java
@@ -37,7 +37,7 @@ public class JAXRSLocatorClient0101
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_locator_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/sub/JAXRSSubClient0100.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/sub/JAXRSSubClient0100.java
@@ -37,7 +37,7 @@ public class JAXRSSubClient0100
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_sub_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/options/JAXRSClient0105.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/options/JAXRSClient0105.java
@@ -40,7 +40,7 @@ public class JAXRSClient0105 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_options_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/JAXRSClient0124.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/JAXRSClient0124.java
@@ -45,7 +45,7 @@ public class JAXRSClient0124 extends JaxrsParamClient0151 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/locator/JAXRSLocatorClient0123.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/locator/JAXRSLocatorClient0123.java
@@ -40,7 +40,7 @@ public class JAXRSLocatorClient0123
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_locator_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/sub/JAXRSSubClient0122.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/sub/JAXRSSubClient0122.java
@@ -40,7 +40,7 @@ public class JAXRSSubClient0122
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_sub_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/produceconsume/JAXRSClient0103.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/produceconsume/JAXRSClient0103.java
@@ -41,7 +41,7 @@ public class JAXRSClient0103 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_produceconsume_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/put/JAXRSClient0109.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/put/JAXRSClient0109.java
@@ -33,7 +33,7 @@ public class JAXRSClient0109 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_put_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/JAXRSClient0150.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/JAXRSClient0150.java
@@ -43,7 +43,7 @@ public class JAXRSClient0150 extends JaxrsParamClient0151 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_queryparam_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/sub/JAXRSSubClient0149.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/sub/JAXRSSubClient0149.java
@@ -40,7 +40,7 @@ public class JAXRSSubClient0149
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_queryparam_sub_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/async/JAXRSClient0181.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/async/JAXRSClient0181.java
@@ -48,7 +48,7 @@ public class JAXRSClient0181
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_executor_async_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/rx/JAXRSClient0182.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/rx/JAXRSClient0182.java
@@ -52,7 +52,7 @@ public class JAXRSClient0182
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_executor_rx_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/rxinvoker/JAXRSClient0180.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/rxinvoker/JAXRSClient0180.java
@@ -57,7 +57,7 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_rxinvoker_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/patch/server/JAXRSClient0179.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/patch/server/JAXRSClient0179.java
@@ -45,7 +45,7 @@ public class JAXRSClient0179 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_patch_server_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/priority/JAXRSClient0178.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/priority/JAXRSClient0178.java
@@ -38,7 +38,7 @@ public class JAXRSClient0178 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_priority_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/ssebroadcaster/JAXRSClient0174.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/ssebroadcaster/JAXRSClient0174.java
@@ -52,7 +52,7 @@ public class JAXRSClient0174 extends SSEJAXRSClient0177 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_sse_ssebroadcaster_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/sseeventsink/JAXRSClient0176.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/sseeventsink/JAXRSClient0176.java
@@ -53,7 +53,7 @@ public class JAXRSClient0176 extends SSEJAXRSClient0177 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_sse_sseeventsink_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/sseeventsource/JAXRSClient0175.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/sse/sseeventsource/JAXRSClient0175.java
@@ -64,7 +64,7 @@ public class JAXRSClient0175 extends SSEJAXRSClient0177 {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_sse_sseeventsource_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonb/JAXRSClient0184.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonb/JAXRSClient0184.java
@@ -53,7 +53,7 @@ public class JAXRSClient0184 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_platform_providers_jsonb_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonp/JAXRSClient0183.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonp/JAXRSClient0183.java
@@ -46,7 +46,7 @@ public class JAXRSClient0183 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_platform_providers_jsonp_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/spec/classsubresourcelocator/JAXRSClient0171.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/spec/classsubresourcelocator/JAXRSClient0171.java
@@ -41,7 +41,7 @@ public class JAXRSClient0171 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_spec_classsubresourcelocator_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/spec/completionstage/JAXRSClient0172.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/spec/completionstage/JAXRSClient0172.java
@@ -43,7 +43,7 @@ public class JAXRSClient0172 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_spec_completionstage_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/JAXRSClient0168.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/JAXRSClient0168.java
@@ -45,7 +45,7 @@ public class JAXRSClient0168 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_beanvalidation_annotation_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/JAXRSClient0169.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/JAXRSClient0169.java
@@ -48,7 +48,7 @@ public class JAXRSClient0169 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path",
                     "/jaxrs_platform_beanvalidation_constraintviolationexceptionmapper_web")

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/JAXRSClient0170.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/JAXRSClient0170.java
@@ -48,7 +48,7 @@ public class JAXRSClient0170 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_beanvalidation_validationexceptionmapper_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/container/asyncresponse/JAXRSClient0163.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/container/asyncresponse/JAXRSClient0163.java
@@ -66,7 +66,7 @@ public class JAXRSClient0163 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_container_asyncresponse_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/container/completioncallback/JAXRSClient0164.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/container/completioncallback/JAXRSClient0164.java
@@ -59,7 +59,7 @@ public class JAXRSClient0164 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_container_completioncallback_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/managedbean299/JAXRSClient0158.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/managedbean299/JAXRSClient0158.java
@@ -41,7 +41,7 @@ public class JAXRSClient0158 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_managedbean299_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/provider/jsonp/JAXRSClient0162.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/provider/jsonp/JAXRSClient0162.java
@@ -41,7 +41,7 @@ public class JAXRSClient0162 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_provider_jsonp_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletapp/JAXRSClient0166.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletapp/JAXRSClient0166.java
@@ -38,7 +38,7 @@ public class JAXRSClient0166 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_servletapp_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletapp1/JAXRSClient0165.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletapp1/JAXRSClient0165.java
@@ -35,7 +35,7 @@ public class JAXRSClient0165 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_servletapp1_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletapp2/JAXRSClient0167.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletapp2/JAXRSClient0167.java
@@ -38,7 +38,7 @@ public class JAXRSClient0167 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_servletapp2_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletconfig/JAXRSClient0160.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletconfig/JAXRSClient0160.java
@@ -38,7 +38,7 @@ public class JAXRSClient0160 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_servletconfig_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletnoapp/JAXRSClient0159.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/platform/servletnoapp/JAXRSClient0159.java
@@ -38,7 +38,7 @@ public class JAXRSClient0159 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_platform_servletnoapp_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/servlet3/rs/applicationpath/JAXRSClient0156.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/servlet3/rs/applicationpath/JAXRSClient0156.java
@@ -40,7 +40,7 @@ public class JAXRSClient0156 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_applicationpath_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/servlet3/rs/core/streamingoutput/JAXRSClient0157.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/servlet3/rs/core/streamingoutput/JAXRSClient0157.java
@@ -42,7 +42,7 @@ public class JAXRSClient0157 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_core_streamoutput_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/servlet3/rs/ext/paramconverter/autodiscovery/JAXRSClient0155.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/servlet3/rs/ext/paramconverter/autodiscovery/JAXRSClient0155.java
@@ -39,7 +39,7 @@ public class JAXRSClient0155 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_servlet3_rs_ext_paramconverter_autodiscovery_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/client/invocations/JAXRSClient0028.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/client/invocations/JAXRSClient0028.java
@@ -48,7 +48,7 @@ public class JAXRSClient0028 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_client_invocations_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/client/resource/JAXRSClient0027.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/client/resource/JAXRSClient0027.java
@@ -38,7 +38,7 @@ public class JAXRSClient0027 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_client_resource_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/client/typedentities/JAXRSClient0025.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/client/typedentities/JAXRSClient0025.java
@@ -65,7 +65,7 @@ public class JAXRSClient0025 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_client_typedentities_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/context/client/JAXRSClient0033.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/context/client/JAXRSClient0033.java
@@ -44,7 +44,7 @@ public class JAXRSClient0033 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_context_client_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/context/server/JAXRSClient0032.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/context/server/JAXRSClient0032.java
@@ -41,7 +41,7 @@ public class JAXRSClient0032 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_context_server_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/dynamicfeature/JAXRSClient0022.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/dynamicfeature/JAXRSClient0022.java
@@ -41,7 +41,7 @@ public class JAXRSClient0022 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_filter_dynamicfeature_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/exception/JAXRSClient0019.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/exception/JAXRSClient0019.java
@@ -43,7 +43,7 @@ public class JAXRSClient0019 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_filter_exception_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/globalbinding/JAXRSClient0023.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/globalbinding/JAXRSClient0023.java
@@ -41,7 +41,7 @@ public class JAXRSClient0023 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_filter_globalbinding_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/interceptor/JAXRSClient0021.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/interceptor/JAXRSClient0021.java
@@ -58,7 +58,7 @@ public class JAXRSClient0021 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_filter_interceptor_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/lastvalue/JAXRSClient0020.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/lastvalue/JAXRSClient0020.java
@@ -46,7 +46,7 @@ public class JAXRSClient0020 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_filter_lastvalue_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/namebinding/JAXRSClient0024.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/filter/namebinding/JAXRSClient0024.java
@@ -41,7 +41,7 @@ public class JAXRSClient0024 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_filter_namebinding_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/inheritance/JAXRSClient0031.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/inheritance/JAXRSClient0031.java
@@ -35,7 +35,7 @@ public class JAXRSClient0031 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_inheritance_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/exceptionmapper/JAXRSClient0004.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/exceptionmapper/JAXRSClient0004.java
@@ -43,7 +43,7 @@ public class JAXRSClient0004 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_exceptionmapper_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/jaxbcontext/JAXRSClient0002.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/jaxbcontext/JAXRSClient0002.java
@@ -44,7 +44,7 @@ public class JAXRSClient0002 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_jaxbcontext_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/overridestandard/JAXRSClient0008.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/overridestandard/JAXRSClient0008.java
@@ -44,7 +44,7 @@ public class JAXRSClient0008 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_overridestandard_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/reader/JAXRSClient0009.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/reader/JAXRSClient0009.java
@@ -42,7 +42,7 @@ public class JAXRSClient0009 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_reader_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/sort/JAXRSClient0007.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/sort/JAXRSClient0007.java
@@ -41,7 +41,7 @@ public class JAXRSClient0007 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_sort_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standard/JAXRSClient0005.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standard/JAXRSClient0005.java
@@ -50,7 +50,7 @@ public class JAXRSClient0005 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_standard_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standardhaspriority/JAXRSClient0001.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standardhaspriority/JAXRSClient0001.java
@@ -47,7 +47,7 @@ public class JAXRSClient0001 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_standardhaspriority_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standardnotnull/JAXRSClient0003.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standardnotnull/JAXRSClient0003.java
@@ -58,7 +58,7 @@ public class JAXRSClient0003 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_standardnotnull_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standardwithjaxrsclient/JAXRSClient0006.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/standardwithjaxrsclient/JAXRSClient0006.java
@@ -44,7 +44,7 @@ public class JAXRSClient0006 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_standardwithjaxrsclient_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/visibility/JAXRSClient0010.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/visibility/JAXRSClient0010.java
@@ -41,7 +41,7 @@ public class JAXRSClient0010 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_visibility_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/writer/JAXRSClient0011.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/provider/writer/JAXRSClient0011.java
@@ -41,7 +41,7 @@ public class JAXRSClient0011 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_provider_writer_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/annotationprecedence/JAXRSClient0014.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/annotationprecedence/JAXRSClient0014.java
@@ -41,7 +41,7 @@ public class JAXRSClient0014 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_resource_annotationprecedence_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/annotationprecedence/subclass/JAXRSClient0013.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/annotationprecedence/subclass/JAXRSClient0013.java
@@ -41,7 +41,7 @@ public class JAXRSClient0013 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_resource_annotationprecedence_subclass_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/locator/JAXRSClient0015.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/locator/JAXRSClient0015.java
@@ -38,7 +38,7 @@ public class JAXRSClient0015 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_resource_locator_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/responsemediatype/JAXRSClient0016.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/responsemediatype/JAXRSClient0016.java
@@ -44,7 +44,7 @@ public class JAXRSClient0016 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_resource_responsemediatype_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/valueofandfromstring/JAXRSClient0017.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resource/valueofandfromstring/JAXRSClient0017.java
@@ -38,7 +38,7 @@ public class JAXRSClient0017 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_resource_valueofandfromstring_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resourceconstructor/JAXRSClient0030.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/resourceconstructor/JAXRSClient0030.java
@@ -41,7 +41,7 @@ public class JAXRSClient0030 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_resourceconstructor_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/returntype/JAXRSClient0018.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/returntype/JAXRSClient0018.java
@@ -42,7 +42,7 @@ public class JAXRSClient0018 extends JaxrsCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_returntype_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/template/JAXRSClient0000.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/spec/template/JAXRSClient0000.java
@@ -36,7 +36,7 @@ public class JAXRSClient0000 extends JAXRSCommonClient {
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
             .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.resteasy-reactive.fail-on-duplicate", "false")
+            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
             .overrideConfigKey("quarkus.rest.default-produces", "false")
             .overrideConfigKey("quarkus.http.root-path", "/jaxrs_spec_templateTest_web")
             .setArchiveProducer(new Supplier<JavaArchive>() {


### PR DESCRIPTION
closes #11 