### PR TITLE
Prepare the TCK tree for JUnit 5.12

### DIFF
--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/asyncinvoker/JAXRSClient0118.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/client/asyncinvoker/JAXRSClient0118.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.AsyncInvoker;
 import jakarta.ws.rs.client.Client;
@@ -48,26 +49,28 @@ import io.quarkus.test.QuarkusUnitTest;
  *                     webServerPort;
  *                     ts_home;
  */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0118 extends JaxrsCommonClient {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_client_asyncinvoker_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.client.asyncinvoker.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.client.asyncinvoker.Resource.class,
-                                    com.sun.ts.tests.jaxrs.common.provider.StringBean.class,
-                                    com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_client_asyncinvoker_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.client.asyncinvoker.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.client.asyncinvoker.Resource.class,
+                                        com.sun.ts.tests.jaxrs.common.provider.StringBean.class,
+                                        com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = -696868584437674095L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/JAXRSClient0143.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/JAXRSClient0143.java
@@ -21,6 +21,7 @@ package com.sun.ts.tests.jaxrs.ee.rs.cookieparam;
 
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -33,41 +34,38 @@ import com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-/*
- * @class.setup_props: webServerHost;
- *                     webServerPort;
- *                     ts_home;
- */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.CookieParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
-
     private static final long serialVersionUID = 1L;
+
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.CookieParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     public JAXRSClient0143() {
         setContextRoot("/jaxrs_ee_rs_cookieparam_web/CookieParamTest");
@@ -85,9 +83,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
     /* Run test */
     /*
      * @testName: cookieParamTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:JAVADOC:145; JAXRS:JAVADOC:2;
-     * 
+     *
      * @test_Strategy: Client invokes GET on root resource at /CookieParamTest;
      * Resource will respond with a cookie; Client verify the cookie is received;
      * Client send request again with the cookie; Verify that the cookie is
@@ -125,10 +123,10 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamEntityWithConstructorTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.2; JAXRS:JAVADOC:12;
      * JAXRS:JAVADOC:12.1;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -138,10 +136,10 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamEntityWithValueOfTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.3; JAXRS:JAVADOC:12;
      * JAXRS:JAVADOC:12.1;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -151,10 +149,10 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.3; JAXRS:JAVADOC:12;
      * JAXRS:JAVADOC:12.1;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -164,10 +162,10 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamSetEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.4; JAXRS:JAVADOC:12;
      * JAXRS:JAVADOC:12.1;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -177,10 +175,10 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamListEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.4; JAXRS:JAVADOC:12;
      * JAXRS:JAVADOC:12.1;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -190,10 +188,10 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamSortedSetEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.4; JAXRS:JAVADOC:12;
      * JAXRS:JAVADOC:12.1;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -203,9 +201,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldParamEntityWithConstructorTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.2; JAXRS:JAVADOC:6;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -215,9 +213,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldParamEntityWithValueOfTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -227,9 +225,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldParamEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.3; JAXRS:JAVADOC:6;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -239,9 +237,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldParamSetEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -251,9 +249,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldParamListEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -263,9 +261,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldSortedSetEntityWithFromStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:5.4; JAXRS:JAVADOC:6;
-     * 
+     *
      * @test_Strategy: Verify that named CookieParam is handled properly
      */
     @Test
@@ -275,13 +273,13 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamThrowingWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:12.3;
-     * 
+     *
      * @test_Strategy: Exceptions thrown during construction of parameter values
      * are treated the same as exceptions thrown during construction of field or
      * bean property values, see section 3.2.
-     * 
+     *
      */
     @Test
     public void cookieParamThrowingWebApplicationExceptionTest() throws Fault {
@@ -290,9 +288,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldThrowingWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:3.4; JAXRS:SPEC:8;
-     * 
+     *
      * @test_Strategy: A WebApplicationException thrown during construction of
      * field or property values using 2 or 3 above is processed directly as
      * described in section 3.3.4.
@@ -304,9 +302,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieParamThrowingIllegalArgumentExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:9; JAXRS:SPEC:9.2; JAXRS:SPEC:10;
-     * 
+     *
      * @test_Strategy: Other exceptions thrown during construction of field or
      * property values using 2 or 3 above are treated as client errors:
      *
@@ -322,9 +320,9 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
 
     /*
      * @testName: cookieFieldParamThrowingIllegalArgumentExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:SPEC:12.3;
-     * 
+     *
      * @test_Strategy: Exceptions thrown during construction of parameter values
      * are treated the same as exceptions thrown during construction of field or
      * bean property values, see section 3.2.
@@ -397,3 +395,8 @@ public class JAXRSClient0143 extends JaxrsParamClient0151 {
                 "");
     }
 }
+/*
+ * @class.setup_props: webServerHost;
+ *                     webServerPort;
+ *                     ts_home;
+ */

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/locator/JAXRSLocatorClient0142.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/locator/JAXRSLocatorClient0142.java
@@ -18,6 +18,7 @@ package com.sun.ts.tests.jaxrs.ee.rs.cookieparam.locator;
 
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
@@ -34,35 +35,36 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSLocatorClient0142
         extends com.sun.ts.tests.jaxrs.ee.rs.cookieparam.JAXRSClient0143 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_locator_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.locator.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.locator.LocatorResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.CookieParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.locator.MiddleResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class);
-                }
-            });
-
     private static final long serialVersionUID = 1L;
+
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_locator_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.locator.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.locator.LocatorResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.CookieParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.locator.MiddleResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class);
+                    }
+                });
+    }
 
     public JAXRSLocatorClient0142() {
         setContextRoot("/jaxrs_ee_rs_cookieparam_locator_web/resource/locator");

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/sub/JAXRSSubClient0141.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/cookieparam/sub/JAXRSSubClient0141.java
@@ -34,34 +34,35 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSSubClient0141
         extends com.sun.ts.tests.jaxrs.ee.rs.cookieparam.JAXRSClient0143 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_sub_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.sub.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.CookieParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.cookieparam.sub.CookieSubResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
-
     private static final long serialVersionUID = 1L;
+
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_cookieparam_sub_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.sub.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.CookieParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.cookieparam.sub.CookieSubResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     public JAXRSSubClient0141() {
         setContextRoot("/jaxrs_ee_rs_cookieparam_sub_web/Resource/subresource");

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/providers/JAXRSProvidersClient0098.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/ext/providers/JAXRSProvidersClient0098.java
@@ -16,8 +16,11 @@
 
 package com.sun.ts.tests.jaxrs.ee.rs.ext.providers;
 
+import java.io.IOException;
 import java.util.function.Supplier;
 
+import com.sun.ts.tests.common.webclient.http.HttpResponse;
+import com.sun.ts.tests.jaxrs.common.JAXRSCommonClient;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
 
@@ -38,7 +41,7 @@ import io.quarkus.test.QuarkusUnitTest;
  */
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSProvidersClient0098
-        extends com.sun.ts.tests.jaxrs.ee.rs.core.application.JAXRSClient0128 {
+        extends JAXRSCommonClient {
 
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
@@ -70,6 +73,10 @@ public class JAXRSProvidersClient0098
 
     private static final long serialVersionUID = -935293219512493643L;
 
+    protected int expectedSingletons = 1;
+
+    protected int expectedClasses = 1;
+
     public JAXRSProvidersClient0098() {
         TSAppConfig cfg = new TSAppConfig();
         setContextRoot("/jaxrs_ee_ext_providers_web/ProvidersServlet");
@@ -91,27 +98,36 @@ public class JAXRSProvidersClient0098
 
     /*
      * @testName: getSingletonsTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:23
-     * 
-     * @test_Strategy: Check that the implementation returns set of
-     * TSAppConfig.CLASSLIST
+     *
+     * @test_Strategy: Check that vi does not modify the getSingletons()
      */
     @Test
     public void getSingletonsTest() throws Fault {
-        super.getSingletonsTest();
+        setProperty(REQUEST, buildRequest(GET, "GetSingletons"));
+        setProperty(STATUS_CODE, getStatusCode(Status.OK));
+        invoke();
+        assertFault(getReturnedNumber() == expectedSingletons,
+                "Application.getSingletons() return incorrect value:",
+                getReturnedNumber());
     }
 
     /*
      * @testName: getClassesTest
-     * 
-     * @assertion_ids: JAXRS:JAVADOC:22
-     * 
+     *
+     * @assertion_ids: JAXRS:JAVADOC:22; JAXRS:SPEC:40;
+     *
      * @test_Strategy: Check the implementation injects TSAppConfig
      */
     @Test
     public void getClassesTest() throws Fault {
-        super.getClassesTest();
+        setProperty(REQUEST, buildRequest(GET, "GetClasses"));
+        setProperty(STATUS_CODE, getStatusCode(Status.OK));
+        invoke();
+        assertFault(getReturnedNumber() == expectedClasses,
+                "Application.getClasses() return incorrect value:",
+                getReturnedNumber());
     }
 
     /*
@@ -470,4 +486,16 @@ public class JAXRSProvidersClient0098
         invoke();
     }
 
+    // ///////////////////////////////////////////////////////////////////////
+
+    protected int getReturnedNumber() throws Fault {
+        HttpResponse response = _testCase.getResponse();
+        String body;
+        try {
+            body = response.getResponseBodyAsString();
+        } catch (IOException e) {
+            throw new Fault(e);
+        }
+        return Integer.parseInt(body);
+    }
 }

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/JAXRSClient0146.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/JAXRSClient0146.java
@@ -18,6 +18,7 @@ package com.sun.ts.tests.jaxrs.ee.rs.formparam;
 
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
 
@@ -35,32 +36,34 @@ import io.quarkus.test.QuarkusUnitTest;
  *                     webServerPort;
  *                     ts_home;
  */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0146 extends JaxrsParamClient0151 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.FormParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.FormParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final String ENCODED = "_%60%27%24X+Y%40%22a+a%22";
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/locator/JAXRSLocatorClient0145.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/locator/JAXRSLocatorClient0145.java
@@ -37,32 +37,33 @@ import io.quarkus.test.QuarkusUnitTest;
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSLocatorClient0145 extends JAXRSClient0146 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_locator_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.locator.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.locator.LocatorResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.locator.MiddleResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.common.AbstractMessageBodyRW.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.FormParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_locator_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.locator.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.locator.LocatorResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.locator.MiddleResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.common.AbstractMessageBodyRW.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.FormParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     public JAXRSLocatorClient0145() {
         setContextRoot("/jaxrs_ee_formparam_locator_web/resource/locator");

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/sub/JAXRSSubClient0144.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/formparam/sub/JAXRSSubClient0144.java
@@ -37,30 +37,31 @@ import io.quarkus.test.QuarkusUnitTest;
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSSubClient0144 extends JAXRSClient0146 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_sub_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.sub.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.sub.SubResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.formparam.FormParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_formparam_sub_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.sub.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.sub.SubResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.formparam.FormParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     public JAXRSSubClient0144() {
         setContextRoot("/jaxrs_ee_formparam_sub_web/resource/sub");

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/JAXRSClient0108.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/JAXRSClient0108.java
@@ -21,6 +21,7 @@ package com.sun.ts.tests.jaxrs.ee.rs.headerparam;
 
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -37,34 +38,36 @@ import io.quarkus.test.QuarkusUnitTest;
  *                     webServerPort;
  *                     ts_home;
  */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0108 extends JaxrsParamClient0151 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.HeaderParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.HeaderParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/locator/JAXRSLocatorClient0107.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/locator/JAXRSLocatorClient0107.java
@@ -34,33 +34,34 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSLocatorClient0107
         extends com.sun.ts.tests.jaxrs.ee.rs.headerparam.JAXRSClient0108 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_locator_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.locator.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.HeaderParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.locator.MiddleResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.locator.LocatorResource.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_locator_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.locator.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.HeaderParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.locator.MiddleResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.locator.LocatorResource.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/sub/JAXRSSubClient0106.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/headerparam/sub/JAXRSSubClient0106.java
@@ -37,32 +37,33 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSSubClient0106
         extends com.sun.ts.tests.jaxrs.ee.rs.headerparam.JAXRSClient0108 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_sub_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.sub.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.sub.SubResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.headerparam.HeaderParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_headerparam_sub_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.sub.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.sub.SubResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.headerparam.HeaderParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = -7534318281215084279L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/JAXRSClient0102.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/JAXRSClient0102.java
@@ -21,6 +21,7 @@ package com.sun.ts.tests.jaxrs.ee.rs.matrixparam;
 
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -37,34 +38,36 @@ import io.quarkus.test.QuarkusUnitTest;
  *                     webServerPort;
  *                     ts_home;
  */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0102 extends JaxrsParamClient0151 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.MatrixParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.MatrixParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/locator/JAXRSLocatorClient0101.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/locator/JAXRSLocatorClient0101.java
@@ -34,33 +34,34 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSLocatorClient0101
         extends com.sun.ts.tests.jaxrs.ee.rs.matrixparam.JAXRSClient0102 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_locator_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.locator.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.locator.LocatorResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.locator.MiddleResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.MatrixParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_locator_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.locator.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.locator.LocatorResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.locator.MiddleResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.MatrixParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/sub/JAXRSSubClient0100.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/matrixparam/sub/JAXRSSubClient0100.java
@@ -34,32 +34,33 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSSubClient0100
         extends com.sun.ts.tests.jaxrs.ee.rs.matrixparam.JAXRSClient0102 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_sub_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.sub.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.sub.SubResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.matrixparam.MatrixParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_matrixparam_sub_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.sub.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.sub.SubResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.matrixparam.MatrixParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/JAXRSClient0124.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/JAXRSClient0124.java
@@ -18,6 +18,7 @@ package com.sun.ts.tests.jaxrs.ee.rs.pathparam;
 
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
 
@@ -39,33 +40,35 @@ import io.quarkus.test.QuarkusUnitTest;
  *                     webServerPort;
  *                     ts_home;
  */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0124 extends JaxrsParamClient0151 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.PathParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.PathParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/locator/JAXRSLocatorClient0123.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/locator/JAXRSLocatorClient0123.java
@@ -37,33 +37,34 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSLocatorClient0123
         extends com.sun.ts.tests.jaxrs.ee.rs.pathparam.JAXRSClient0124 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_locator_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.MiddleResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.PathParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.PathSegmentImpl.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.LocatorResource.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_locator_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.MiddleResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.PathParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.PathSegmentImpl.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.locator.LocatorResource.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/sub/JAXRSSubClient0122.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/pathparam/sub/JAXRSSubClient0122.java
@@ -37,31 +37,32 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSSubClient0122
         extends com.sun.ts.tests.jaxrs.ee.rs.pathparam.JAXRSClient0124 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_sub_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.sub.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.PathParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.pathparam.sub.SubResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_pathparam_sub_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.sub.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.PathParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.pathparam.sub.SubResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/JAXRSClient0150.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/JAXRSClient0150.java
@@ -21,6 +21,7 @@ package com.sun.ts.tests.jaxrs.ee.rs.queryparam;
 
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -37,34 +38,36 @@ import io.quarkus.test.QuarkusUnitTest;
  *                     webServerPort;
  *                     ts_home;
  */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0150 extends JaxrsParamClient0151 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_queryparam_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.queryparam.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.queryparam.QueryParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_queryparam_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.queryparam.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.queryparam.QueryParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/sub/JAXRSSubClient0149.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/ee/rs/queryparam/sub/JAXRSSubClient0149.java
@@ -37,32 +37,33 @@ import io.quarkus.test.QuarkusUnitTest;
 public class JAXRSSubClient0149
         extends com.sun.ts.tests.jaxrs.ee.rs.queryparam.JAXRSClient0150 {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_queryparam_sub_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.ee.rs.queryparam.sub.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.queryparam.sub.SubResource.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.queryparam.QueryParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_ee_rs_queryparam_sub_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.ee.rs.queryparam.sub.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.JaxrsParamClient0151.CollectionName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.WebApplicationExceptionMapper.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithValueOf.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.queryparam.sub.SubResource.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingExceptionGivenByName.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.queryparam.QueryParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithFromString.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityThrowingWebApplicationException.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityWithConstructor.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamEntityPrototype.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.ParamTest.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.RuntimeExceptionMapper.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/async/JAXRSClient0181.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/async/JAXRSClient0181.java
@@ -45,22 +45,23 @@ public class JAXRSClient0181
         extends com.sun.ts.tests.jaxrs.ee.rs.client.asyncinvoker.JAXRSClient0118
         implements ExecutorServiceChecker {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_executor_async_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.jaxrs21.ee.client.executor.async.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.ee.rs.client.asyncinvoker.Resource.class,
-                                    com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_executor_async_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.jaxrs21.ee.client.executor.async.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.ee.rs.client.asyncinvoker.Resource.class,
+                                        com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 21L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/rx/JAXRSClient0182.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/executor/rx/JAXRSClient0182.java
@@ -49,22 +49,23 @@ public class JAXRSClient0182
         extends com.sun.ts.tests.jaxrs.jaxrs21.ee.client.rxinvoker.JAXRSClient0180
         implements ExecutorServiceChecker {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_executor_rx_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.jaxrs21.ee.client.executor.rx.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.jaxrs21.ee.client.rxinvoker.Resource.class,
-                                    com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_executor_rx_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.jaxrs21.ee.client.executor.rx.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.jaxrs21.ee.client.rxinvoker.Resource.class,
+                                        com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 21L;
 

--- a/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/rxinvoker/JAXRSClient0180.java
+++ b/tests/src/test/java/com/sun/ts/tests/jaxrs/jaxrs21/ee/client/rxinvoker/JAXRSClient0180.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
+import io.quarkus.test.DelegatingQuarkusUnitTestExtension;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -51,25 +52,27 @@ import io.quarkus.test.QuarkusUnitTest;
 /**
  * @since 2.1
  */
+@org.junit.jupiter.api.extension.ExtendWith(DelegatingQuarkusUnitTestExtension.class)
 @org.junit.jupiter.api.extension.ExtendWith(com.sun.ts.tests.TckExtention.class)
 public class JAXRSClient0180 extends JAXRSCommonClient {
 
-    @RegisterExtension
-    static QuarkusUnitTest test = new QuarkusUnitTest().setFlatClassPath(true)
-            .overrideConfigKey("quarkus.rest.single-default-produces", "false")
-            .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
-            .overrideConfigKey("quarkus.rest.default-produces", "false")
-            .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_rxinvoker_web")
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(
-                                    com.sun.ts.tests.jaxrs.jaxrs21.ee.client.rxinvoker.TSAppConfig.class,
-                                    com.sun.ts.tests.jaxrs.jaxrs21.ee.client.rxinvoker.Resource.class,
-                                    com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
-                }
-            });
+    public static QuarkusUnitTest createQuarkusUnitTest() {
+        return new QuarkusUnitTest().setFlatClassPath(true)
+                .overrideConfigKey("quarkus.rest.single-default-produces", "false")
+                .overrideConfigKey("quarkus.rest.fail-on-duplicate", "false")
+                .overrideConfigKey("quarkus.rest.default-produces", "false")
+                .overrideConfigKey("quarkus.http.root-path", "/jaxrs_jaxrs21_ee_client_rxinvoker_web")
+                .setArchiveProducer(new Supplier<JavaArchive>() {
+                    @Override
+                    public JavaArchive get() {
+                        return ShrinkWrap.create(JavaArchive.class)
+                                .addClasses(
+                                        com.sun.ts.tests.jaxrs.jaxrs21.ee.client.rxinvoker.TSAppConfig.class,
+                                        com.sun.ts.tests.jaxrs.jaxrs21.ee.client.rxinvoker.Resource.class,
+                                        com.sun.ts.tests.jaxrs.common.impl.TRACE.class);
+                    }
+                });
+    }
 
     private static final long serialVersionUID = 21L;
 
@@ -104,9 +107,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     // --------------------------------------------------------------------
     /*
      * @testName: deleteTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1134; JAXRS:JAVADOC:1162;
-     * 
+     *
      * @test_Strategy: Invoke HTTP DELETE method for the current request.
      */
     @org.junit.jupiter.api.Test
@@ -119,9 +122,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteThrowsExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1134; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1164;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -136,11 +139,11 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithStringClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1164;
-     * 
+     *
      * @test_Strategy: Invoke HTTP DELETE method for the current request
-     * 
+     *
      */
     @org.junit.jupiter.api.Test
     public Future<String> deleteWithStringClassTest() throws Fault {
@@ -152,11 +155,11 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithResponseClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
-     * 
+     *
      * @test_Strategy: Invoke HTTP DELETE method for the current request
-     * 
+     *
      */
     @org.junit.jupiter.api.Test
     public Future<Response> deleteWithResponseClassTest() throws Fault {
@@ -168,9 +171,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithClassThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -185,9 +188,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithClassThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -201,9 +204,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithClassThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1135; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1165;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -218,9 +221,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithGenericTypeStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
-     * 
+     *
      * @test_Strategy: Invoke HTTP DELETE method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -234,9 +237,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithGenericTypeResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
-     * 
+     *
      * @test_Strategy: Invoke HTTP DELETE method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -250,9 +253,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithGenericTypeThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -269,9 +272,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: deleteWithGenericTypeThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -288,9 +291,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     /*
      * @testName:
      * deleteWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1136; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1166;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -310,9 +313,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1137; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1167;
-     * 
+     *
      * @test_Strategy: Invoke HTTP GET method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -325,9 +328,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1137; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1167;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -342,9 +345,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithStringClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
-     * 
+     *
      * @test_Strategy: Invoke HTTP GET method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -357,9 +360,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithResponseClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
-     * 
+     *
      * @test_Strategy: Invoke HTTP GET method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -372,9 +375,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithClassThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -389,9 +392,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithClassThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -405,9 +408,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithClassThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1138; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1168;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -422,9 +425,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithGenericTypeStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
-     * 
+     *
      * @test_Strategy: Invoke HTTP GET method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -438,9 +441,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithGenericTypeResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
-     * 
+     *
      * @test_Strategy: Invoke HTTP GET method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -454,9 +457,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithGenericTypeThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -472,9 +475,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithGenericTypeThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -490,9 +493,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: getWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1139; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1169;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -512,9 +515,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: headTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1140; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1170;
-     * 
+     *
      * @test_Strategy: Invoke HTTP HEAD method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -527,9 +530,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: headThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1140; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1170;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -548,9 +551,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1141; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1171;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -567,9 +570,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1141; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1171;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -588,9 +591,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithStringClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -607,9 +610,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithResponseClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -626,9 +629,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithClassThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -647,9 +650,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithClassThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -667,9 +670,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithClassThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1142; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1172;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -688,9 +691,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -708,9 +711,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -728,9 +731,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -751,9 +754,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -774,9 +777,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     /*
      * @testName:
      * methodWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1143; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1173;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -796,9 +799,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithEntityTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1144; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1174;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -816,9 +819,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithEntityThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1144; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1174;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -838,9 +841,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithStringClassWithEntityTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -858,9 +861,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithResponseClassWithEntityTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -878,9 +881,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithClassWithEntityThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -901,9 +904,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithClassWithEntityThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -924,9 +927,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     /*
      * @testName:
      * methodWithClassWithEntityThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1145; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1175;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -946,9 +949,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeStringWithEntityTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -968,9 +971,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeResponseWithEntityTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
-     * 
+     *
      * @test_Strategy: Invoke an arbitrary method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -990,9 +993,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeWithEntityThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1014,9 +1017,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: methodWithGenericTypeWithEntityThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1038,9 +1041,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     /*
      * @testName:
      * methodWithGenericTypeWithEntityThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1146; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1176;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1065,9 +1068,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1147; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1177;
-     * 
+     *
      * @test_Strategy: Invoke HTTP options method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1080,9 +1083,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1147; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1177;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1097,9 +1100,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithStringClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
-     * 
+     *
      * @test_Strategy: Invoke HTTP options method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1112,9 +1115,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithResponseClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
-     * 
+     *
      * @test_Strategy: Invoke HTTP options method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1127,9 +1130,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithClassThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1144,9 +1147,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithClassThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1160,9 +1163,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithClassThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1148; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1178;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1177,9 +1180,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithGenericTypeStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
-     * 
+     *
      * @test_Strategy: Invoke HTTP options method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1193,9 +1196,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithGenericTypeResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
-     * 
+     *
      * @test_Strategy: Invoke HTTP options method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1209,9 +1212,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithGenericTypeThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1228,9 +1231,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: optionsWithGenericTypeThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1247,9 +1250,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     /*
      * @testName:
      * optionsWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1149; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1179;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1269,9 +1272,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1150; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1180;
-     * 
+     *
      * @test_Strategy: Invoke HTTP post method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1285,9 +1288,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1150; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1180;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1303,9 +1306,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithStringClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
-     * 
+     *
      * @test_Strategy: Invoke HTTP post method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1319,9 +1322,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithResponseClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
-     * 
+     *
      * @test_Strategy: Invoke HTTP post method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1336,9 +1339,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithClassThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1354,9 +1357,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithClassThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1371,9 +1374,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithClassThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1151; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1181;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1390,9 +1393,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithGenericTypeStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
-     * 
+     *
      * @test_Strategy: Invoke HTTP post method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1407,9 +1410,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithGenericTypeResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
-     * 
+     *
      * @test_Strategy: Invoke HTTP post method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1424,9 +1427,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithGenericTypeThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1443,9 +1446,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: postWithGenericTypeThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1463,9 +1466,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     /*
      * @testName:
      * postWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1152; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1182;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1486,9 +1489,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1153; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1183;
-     * 
+     *
      * @test_Strategy: Invoke HTTP PUT method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1502,9 +1505,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1153; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1183;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1520,9 +1523,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithStringClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
-     * 
+     *
      * @test_Strategy: Invoke HTTP put method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1536,9 +1539,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithResponseClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
-     * 
+     *
      * @test_Strategy: Invoke HTTP put method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1553,9 +1556,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithClassThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1571,9 +1574,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithClassThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1588,9 +1591,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithClassThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1154; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1184;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1607,9 +1610,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithGenericTypeStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
-     * 
+     *
      * @test_Strategy: Invoke HTTP put method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1624,9 +1627,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithGenericTypeResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
-     * 
+     *
      * @test_Strategy: Invoke HTTP put method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1641,9 +1644,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithGenericTypeThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1660,9 +1663,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithGenericTypeThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1679,9 +1682,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: putWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1155; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1185;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1702,9 +1705,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1156; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1186;
-     * 
+     *
      * @test_Strategy: Invoke HTTP trace method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1717,9 +1720,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1156; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1186;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1734,9 +1737,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithStringClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
-     * 
+     *
      * @test_Strategy: Invoke HTTP trace method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1749,9 +1752,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithResponseClassTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
-     * 
+     *
      * @test_Strategy: Invoke HTTP trace method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1764,9 +1767,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithClassThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1781,9 +1784,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithClassThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1797,9 +1800,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithClassThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1157; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1187;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1814,9 +1817,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithGenericTypeStringTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
-     * 
+     *
      * @test_Strategy: Invoke HTTP trace method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1830,9 +1833,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithGenericTypeResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
-     * 
+     *
      * @test_Strategy: Invoke HTTP trace method for the current request
      */
     @org.junit.jupiter.api.Test
@@ -1846,9 +1849,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithGenericTypeThrowsProcessingExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
-     * 
+     *
      * @test_Strategy: ResponseProcessingException - in case processing of a
      * received HTTP response fails (e.g. in a filter or during conversion of the
      * response entity data to an instance of a particular Java type).
@@ -1864,9 +1867,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
 
     /*
      * @testName: traceWithGenericTypeThrowsWebApplicationExceptionTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.
@@ -1883,9 +1886,9 @@ public class JAXRSClient0180 extends JAXRSCommonClient {
     /*
      * @testName:
      * traceWithGenericTypeThrowsNoWebApplicationExceptionForResponseTest
-     * 
+     *
      * @assertion_ids: JAXRS:JAVADOC:1158; JAXRS:JAVADOC:1162; JAXRS:JAVADOC:1188;
-     * 
+     *
      * @test_Strategy: WebApplicationException - in case the response status code
      * of the response returned by the server is not successful and the specified
      * response type is not Response.


### PR DESCRIPTION
We cannot override a static field anymore and... that being said, considering the failures I see, I think it wasn't working very well before.

The following core PR is required for experimenting with this work: https://github.com/quarkusio/quarkus/pull/46871

A good example of this problem is JAXRSProvidersClient0098:

- The test should fail with a NoClassDefFoundError as `getPropertiesTest()` in the parent class `JAXRSClient0128` is relying on `....core.application.TSAppConfig` being present and this test includes `....ext.providers.TSAppConfig` instead.
- But the test doesn't fail.
- In the Jakarta REST TCK, they actually broke the hierarchy in the latest version and `JAXRSProvidersClient0098` is now depending on `JAXRSCommonClient` instead

-> I applied the same change here.

BUT... there are a lot more failures we need to diagnose. Some of them are quite similar so I suspect there aren't that many issues.